### PR TITLE
feat: Improve error message for missing GitHub callback URL

### DIFF
--- a/backend/src/controllers/auth.Controller.js
+++ b/backend/src/controllers/auth.Controller.js
@@ -53,7 +53,7 @@ const redirectToGitHub = asyncHandler(async (req, res) => {
   const authUrl = 'https://github.com/login/oauth/authorize';
   const callbackURL = process.env.GITHUB_CALLBACK_URL;
   if (!callbackURL) {
-    throw new ApiError(500, 'GitHub Callback URL is not configured.');
+    throw new ApiError(500, 'GitHub Callback URL is not configured. Please set the GITHUB_CALLBACK_URL environment variable.');
   }
 
   // This logging is crucial for debugging your production 404 error


### PR DESCRIPTION
The previous error message for a missing GitHub callback URL was generic. This change makes the error message more descriptive by explicitly stating that the `GITHUB_CALLBACK_URL` environment variable needs to be set.

This will help developers quickly identify and resolve the configuration issue in the future.