### PR TITLE
fix: remove AuthDebugPanel import from App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,7 @@ import DashboardPage from './pages/DashboardPage';
 import DebugPage from './pages/DebugPage';
 import LoadingSpinner from './components/LoadingSpinner';
 import ErrorBoundary from './components/ErrorBoundary';
-import AuthDebugPanel from './components/AuthDebugPanel';
+
 
 // Protected Route Component
 const ProtectedRoute = ({ children }) => {
@@ -205,7 +205,6 @@ function App() {
       <ErrorBoundary>
         <AuthProvider>
           <AppRoutes />
-          <AuthDebugPanel />
           <Toaster
             position="top-right"
             toastOptions={{


### PR DESCRIPTION
- Remove import statement for AuthDebugPanel component
- Remove AuthDebugPanel component usage from App component
- Fixes build error: Could not resolve './components/AuthDebugPanel'

This resolves the Vercel build failure caused by importing a component that was removed from git tracking in the previous cleanup commit.